### PR TITLE
Drop Node < 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack": "5.82.1"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16.*"
+    "node": ">= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
I currently can't develop locally as the package.json is underspecified, so we have some options

- Drop Node 18, then use latest pnpm (9) (breaking change)
- Specify pnpm 7, keep existing node support -- see this alternate PR: https://github.com/mainmatter/ember-hbs-minifier/pull/722