### PR TITLE
Specify pnpm @ 7 via `packageManager` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "qunit": "2.19.4",
     "webpack": "5.82.1"
   },
+  "packageManager": "pnpm@^7.33.7",
   "engines": {
     "node": "12.* || 14.* || >= 16.*"
   },


### PR DESCRIPTION
Alternative to https://github.com/mainmatter/ember-hbs-minifier/pull/721
Closes https://github.com/mainmatter/ember-hbs-minifier/pull/721


This PR keeps the existing node support and doesn't incur a breaking change.